### PR TITLE
Add Spanish site link to header

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -207,7 +207,19 @@ const config = {
             'aria-label': 'Spanish Site',
             className: 'navbar--spanish-link',
             href: 'https://blupblurp.github.io/luminescent-team-esp/',
-            position: 'right',
+            position: 'left',
+          },
+          {
+            type: 'dropdown',
+            label: 'Language',
+            className: 'navbar--language-dropdown',
+            position: 'left',
+            items: [
+              {
+                label: 'Español',
+                href: 'https://blupblurp.github.io/luminescent-team-esp/',
+              },
+            ],
           },
           {
             'aria-label': 'Discord Invite',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -207,7 +207,7 @@ const config = {
             'aria-label': 'Spanish Site',
             className: 'navbar--spanish-link',
             href: 'https://blupblurp.github.io/luminescent-team-esp/',
-            position: 'left',
+            position: 'right',
           },
           {
             type: 'dropdown',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -204,6 +204,12 @@ const config = {
             ],
           },
           {
+            'aria-label': 'Spanish Site',
+            className: 'navbar--spanish-link',
+            href: 'https://blupblurp.github.io/luminescent-team-esp/',
+            position: 'right',
+          },
+          {
             'aria-label': 'Discord Invite',
             className: 'navbar--discord-link',
             href: 'https://discord.gg/luminescent',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -83,6 +83,30 @@ div.evolutionTables > table td:nth-child(even) {
 }
 
 /* navbar */
+.navbar--spanish-link {
+	width: 32px;
+	height: 32px;
+	padding: 6px;
+	margin-right: 6px;
+	margin-left: 6px;
+	border-radius: 50%;
+	transition: background var(--ifm-transition-fast);
+}
+
+.navbar--spanish-link:hover {
+	background: var(--ifm-color-emphasis-200);
+}
+
+.navbar--spanish-link:before {
+	content: '';
+	height: 100%;
+	display: block;
+	background: url("data:image/svg+xml,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Crect y='0' width='32' height='8' fill='%23AA151B'/%3E%3Crect y='8' width='32' height='16' fill='%23F1BF00'/%3E%3Crect y='24' width='32' height='8' fill='%23AA151B'/%3E%3C/svg%3E");
+	background-size: contain;
+	background-repeat: no-repeat;
+	background-position: center;
+}
+
 .navbar--discord-link {
 	width: 32px;
 	height: 32px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -84,17 +84,32 @@ div.evolutionTables > table td:nth-child(even) {
 
 /* navbar */
 .navbar--spanish-link {
-	width: 32px;
-	height: 32px;
-	padding: 6px;
-	margin-right: 6px;
-	margin-left: 6px;
 	border-radius: 50%;
 	transition: background var(--ifm-transition-fast);
 }
 
 .navbar--spanish-link:hover {
 	background: var(--ifm-color-emphasis-200);
+}
+
+/* Desktop: icon only */
+.navbar--spanish-link.navbar__link {
+	width: 32px;
+	height: 32px;
+	padding: 6px;
+	margin-right: 6px;
+	margin-left: 6px;
+	overflow: hidden;
+}
+
+/* Mobile sidebar: the icon link is replaced by the Language dropdown */
+.menu__list-item:has(> .menu__link.navbar--spanish-link) {
+	display: none;
+}
+
+/* Desktop: hide the mobile-only Language dropdown */
+.navbar__item.dropdown:has(> .navbar__link.navbar--language-dropdown) {
+	display: none;
 }
 
 .navbar--spanish-link:before {


### PR DESCRIPTION
Adds a Spanish icon to the header that links to the translated Spanish site.
Future translated sites can be added the same way.
Icon is from w3.org